### PR TITLE
added make_comppare helper

### DIFF
--- a/examples/advanced_demo/1-custom_error_policy/custom_error_policy_demo.cpp
+++ b/examples/advanced_demo/1-custom_error_policy/custom_error_policy_demo.cpp
@@ -40,10 +40,7 @@ void car3(car &c)
 
 int main(int argc, char **argv)
 {
-    comppare::
-        InputContext<>::
-            OutputContext<comppare::set_policy<car, IsSameBrand>>
-                compare;
+    auto compare = comppare::make_comppare<comppare::set_policy<car, IsSameBrand>>();
 
     compare.set_reference("Toyota Prius", car1);
     compare.add("Toyota Corolla", car2);

--- a/examples/advanced_demo/2-google_benchmark/google_benchmark_demo.cpp
+++ b/examples/advanced_demo/2-google_benchmark/google_benchmark_demo.cpp
@@ -45,10 +45,7 @@ int main(int argc, char **argv)
     std::iota(input.begin(), input.end(), 1);
 
     // Create an instance of the ComPPare framework
-    comppare::
-        InputContext<std::vector<int>>::
-            OutputContext<std::vector<int>>
-                compare(input);
+    auto compare = comppare::make_comppare<std::vector<int>>(input);
 
     // Register the implementations 
     // Add .google_benchmark() to enable Google Benchmark for the particular implementation

--- a/examples/advanced_demo/3-manual_timing/manual_timing_demo.cpp
+++ b/examples/advanced_demo/3-manual_timing/manual_timing_demo.cpp
@@ -93,7 +93,7 @@ static void bench_clear_square(std::vector<int> &v)
 
 int main(int argc, char **argv)
 {
-    comppare::InputContext<>::OutputContext<std::vector<int>> compare;
+    auto compare = comppare::make_comppare<std::vector<int>>();
 
     compare.set_reference("All", bench_all).google_benchmark()
                                             ->Unit(benchmark::kMicrosecond);

--- a/examples/advanced_demo/4-DoNotOptimize/DoNotOptimize_demo.cpp
+++ b/examples/advanced_demo/4-DoNotOptimize/DoNotOptimize_demo.cpp
@@ -36,10 +36,7 @@ int main(int argc, char **argv)
     std::iota(x, x + N, 1.0f);
     std::iota(y, y + N, 1.0f);
 
-    comppare::
-        InputContext<const float, const float*, const float*>::
-            OutputContext<>
-                compare(a, x, y);
+    auto compare = comppare::make_comppare<>(a, x, y);
 
 #ifdef HAVE_GOOGLE_BENCHMARK
     compare.set_reference("SAXPY", SAXPY).google_benchmark();

--- a/examples/advanced_demo/5-nvbench/saxpy_nvbench.cu
+++ b/examples/advanced_demo/5-nvbench/saxpy_nvbench.cu
@@ -50,10 +50,10 @@ int main(int argc, char **argv)
     std::vector<float> x(n, 2.2f);
     std::vector<float> y(n, 3.3f);
 
-    comppare::InputContext<float, std::vector<float>, std::vector<float>>::OutputContext<std::vector<float>> cmp(a, x, y);
+    auto compare = comppare::make_comppare<std::vector<float>>(a, x, y);
 
-    cmp.add("saxpy gpu", saxpy_gpu).nvbench();
-    cmp.add("saxpy cpu", saxpy_cpu).nvbench().set_is_cpu_only(true);
+    compare.add("saxpy gpu", saxpy_gpu).nvbench();
+    compare.add("saxpy cpu", saxpy_cpu).nvbench().set_is_cpu_only(true);
 
-    cmp.run(argc, argv);
+    compare.run(argc, argv);
 }

--- a/examples/max_reduction/main.cpp
+++ b/examples/max_reduction/main.cpp
@@ -12,11 +12,10 @@ int main(int argc, char **argv)
     // Initialize configuration
     MaxConfig cfg = init_max(argc, argv);
 
-    // Define the input and output types for the comparison framework instance
-    comppare::
-        InputContext<std::span<const float>>::
-            OutputContext<float>
-                compare(cfg.data);
+    // Using make_comppare helper to create a comppare instance
+    // comppare::make_comppare<output_types>(input_args);
+    // equivalent to comppare::InputContext<std::span<const float>>::OutputContext<float>
+    auto compare = comppare::make_comppare<float>(cfg.data);
 
     // Set reference implementation
     compare.set_reference("cpu serial", cpu_max_serial);

--- a/examples/saxpy/main.cpp
+++ b/examples/saxpy/main.cpp
@@ -14,14 +14,9 @@ int main(int argc, char **argv)
     SaxpyConfig cfg = init_saxpy(argc, argv);
     comppare::config::set_fp_tolerance(float(1.0f));
 
-    // Define the input and output types for the comparison framework instance
-    using ScalarType = float;
-    using VectorType = std::vector<float>;
-
-    comppare::
-        InputContext<ScalarType, VectorType, VectorType>::
-            OutputContext<VectorType>
-                compare(cfg.a, cfg.x, cfg.y);
+    // Using make_comppare helper to create a comppare instance
+    // comppare::make_comppare<output_types>(input_args);
+    auto compare = comppare::make_comppare<std::vector<float>>(cfg.a, cfg.x, cfg.y);
 
     // Set reference implementation
     compare.set_reference("cpu serial", cpu_std);

--- a/include/comppare/comppare.hpp
+++ b/include/comppare/comppare.hpp
@@ -849,6 +849,27 @@ namespace comppare
             } /* run */
         }; /* OutputContext */
     }; /* InputContext */
+
+    /**
+     * @brief Helper function to create a comppare object.
+     * 
+     * This function simplifies the creation of a comppare object by deducing the input types.
+     * It takes input arguments and returns an `OutputContext` object that can be used to add implementations and run comparisons.
+     * The output types must be specified explicitly as template parameters, while the input types are deduced from the function arguments.
+     * The function arguments are perfectly forwarded to instantiate the `OutputContext` object.
+     * 
+     * @tparam Outputs The types of the output specifications.
+     * @tparam Inputs The types of the input specifications -- deduced from function arguments.
+     * @param ins The input arguments.
+     * @return typename InputContext<Inputs...>::OutputContext<Outputs...>
+     */
+    template <typename... Outputs, typename... Inputs>
+    auto make_comppare(Inputs&&... ins) {
+        return typename InputContext<std::decay_t<Inputs>...>::template 
+            OutputContext<std::decay_t<Outputs>...>(
+            std::forward<Inputs>(ins)...
+        );
+    }
 } // namespace comppare
 
 /**

--- a/include/comppare/internal/policy.hpp
+++ b/include/comppare/internal/policy.hpp
@@ -373,8 +373,8 @@ namespace comppare::internal::policy
             T total_error_ = T(0);
             std::size_t elem_cnt_ = 0;
 
-            bool fail_{false};
-            bool valid_{true};
+            bool fail_{false};  /** < @brief Indicates if the current error state is a failure. */
+            bool valid_{true};  /** < @brief Indicates if the current error state is valid. */
             std::string err_msg_;
 
             T tolerance_;
@@ -434,17 +434,26 @@ namespace comppare::internal::policy
                 }
             }
 
+            /**
+             * @brief Checks if the current error state is a failure.
+             * 
+             * @return true if the error state is a failure, false otherwise.
+             * if the error state is invalid, it returns false.
+             */
             bool is_fail() const
             {
-                if (!valid_)
+                if (valid_)
                     return fail_;
+                else
+                    return false;
             }
 
             void compute_error(const R &a, const R &b)
             {
                 if (std::ranges::size(a) != std::ranges::size(b))
                 {
-                    valid_ = false;
+                    // invalid if sizes are different
+                    valid_ = false; 
                     err_msg_ = "Size mismatch";
                     elem_cnt_ = 0;
                     return;
@@ -462,6 +471,7 @@ namespace comppare::internal::policy
                             total_error_ = std::numeric_limits<T>::quiet_NaN();
                             elem_cnt_ = 0;
 
+                            // invalid if any element is NAN/INF
                             valid_ = false;
                             err_msg_ = "NAN/INF";
                             return;


### PR DESCRIPTION
Added and validated make_comppare helper function 

Example for testing a function:
```cpp
void foo(const float, std::string, int)
```
where `float` is the input and `std::string, int` are the output

Originally:
```cpp
float a = 10.0f;
comppare::InputContext<float>::OutputContext<std::string> compare(a) //compare object
```

With make_comppare:
```cpp
float a = 10.0f;
auto compare = comppare::make_comppare<std::string, int>(a);
```
make_comppare takes in the output types as the template arguments, while the input types are deduced from the input data.